### PR TITLE
Add cache to DiscoverToggleTypesService

### DIFF
--- a/src/Esquio.UI/Infrastructure/Services/DiscoverToggleTypesService.cs
+++ b/src/Esquio.UI/Infrastructure/Services/DiscoverToggleTypesService.cs
@@ -10,19 +10,26 @@ namespace Esquio.UI.Infrastructure.Services
     public class DiscoverToggleTypesService
         : IDiscoverToggleTypesService
     {
+        private static IEnumerable<Type> _typesCache;
+
         public IEnumerable<Type> Scan()
         {
-            return AppDomain.CurrentDomain
-                .GetAssemblies()
-                .Intersect(IntrospectionAssemblies)
-                .SelectMany(a => a.GetExportedTypes())
-                .Where(type => typeof(IToggle).IsAssignableFrom(type) && type.IsClass);
+            if (_typesCache is null)
+            {
+                _typesCache = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .Intersect(IntrospectionAssemblies)
+                    .SelectMany(a => a.GetExportedTypes())
+                    .Where(type => typeof(IToggle).IsAssignableFrom(type) && type.IsClass);
+            }
+
+            return _typesCache;
         }
 
         private static IEnumerable<Assembly> IntrospectionAssemblies = new Assembly[]
         {
             typeof(Toggles.OnToggle).Assembly,
-            typeof(AspNetCore.Toggles.ClaimValueToggle).Assembly,
+            typeof(AspNetCore.Toggles.ClaimValueToggle).Assembly
             //<--- add your custom toggle assemblies here!
         };
     }


### PR DESCRIPTION
Add cache to DiscoverToggleTypesService in order to avoid access to the AppDomain everytime you need to scan for toggles types.

Regards!