### PR TITLE
Add Feature Blazor component

### DIFF
--- a/Esquio.sln
+++ b/Esquio.sln
@@ -43,7 +43,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Esquio.AspNetCore.Applicati
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{89B085DE-0270-49E9-8AC7-1B1D7119E962}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiniProfiler.Esquio", "tools\MiniProfiler.Esquio\MiniProfiler.Esquio.csproj", "{5B9AB74E-82E6-41C9-AD07-D8883EEA4480}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiniProfiler.Esquio", "tools\MiniProfiler.Esquio\MiniProfiler.Esquio.csproj", "{5B9AB74E-82E6-41C9-AD07-D8883EEA4480}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Esquio.AspNetCore/Blazor/Feature.cs
+++ b/src/Esquio.AspNetCore/Blazor/Feature.cs
@@ -1,0 +1,71 @@
+﻿using Esquio.Abstractions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.Primitives;
+using System.Threading.Tasks;
+
+namespace Esquio.AspNetCore.Blazor
+{
+    public class Feature : ComponentBase
+    {
+        private bool isEnabled;
+        private static readonly char[] FeatureSeparator = new[] { ',' };
+
+        /// <summary>
+        /// The product name that determines whether the content can be displayed. If you do not specicify a product name,
+        /// default will be used.
+        /// </summary>
+        [Parameter] public string Product { get; set; } = "default";
+
+        /// <summary>
+        /// A comma delimited list of feature names that are allowed to display the content.
+        /// </summary>
+        [Parameter] public string Names { get; set; }
+
+        /// <summary>
+        /// The content that will be displayed if the features is enabled.
+        /// </summary>
+        [Parameter] public RenderFragment Enabled { get; set; }
+
+        /// <summary>
+        /// The content that will be displayed if the feature is disabled.
+        /// </summary>
+        [Parameter] public RenderFragment Disabled { get; set; }
+
+        [Inject] private IFeatureService FeatureService { get; set; }
+
+        /// <inheritdoc />
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            if (isEnabled)
+            {
+                builder.AddContent(0, Enabled);
+            }
+            else
+            {
+                builder.AddContent(0, Disabled);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override async Task OnParametersSetAsync()
+        {
+            var features = new StringTokenizer(Names, FeatureSeparator);
+
+            foreach (var item in features)
+            {
+                var featureName = item.Trim();
+
+                if (featureName.HasValue && featureName.Length > 0)
+                {
+                    isEnabled = await FeatureService.IsEnabledAsync(featureName.Value, Product);
+
+                    if (!isEnabled)
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Esquio.AspNetCore/Blazor/Feature.cs
+++ b/src/Esquio.AspNetCore/Blazor/Feature.cs
@@ -8,14 +8,14 @@ namespace Esquio.AspNetCore.Blazor
 {
     public class Feature : ComponentBase
     {
-        private bool isEnabled;
+        private bool _isEnabled;
         private static readonly char[] FeatureSeparator = new[] { ',' };
 
         /// <summary>
         /// The product name that determines whether the content can be displayed. If you do not specicify a product name,
         /// default will be used.
         /// </summary>
-        [Parameter] public string Product { get; set; } = "default";
+        [Parameter] public string Product { get; set; } = EsquioConstants.DEFAULT_PRODUCT_NAME;
 
         /// <summary>
         /// A comma delimited list of feature names that are allowed to display the content.
@@ -37,7 +37,7 @@ namespace Esquio.AspNetCore.Blazor
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            if (isEnabled)
+            if (_isEnabled)
             {
                 builder.AddContent(0, Enabled);
             }
@@ -58,9 +58,9 @@ namespace Esquio.AspNetCore.Blazor
 
                 if (featureName.HasValue && featureName.Length > 0)
                 {
-                    isEnabled = await FeatureService.IsEnabledAsync(featureName.Value, Product);
+                    _isEnabled = await FeatureService.IsEnabledAsync(featureName.Value, Product);
 
-                    if (!isEnabled)
+                    if (!_isEnabled)
                     {
                         return;
                     }


### PR DESCRIPTION
I've added suport for Blazor components like TagHelper in Esquio MVC. Please review naming and docs. The component support Enabled and Disabled RenderFragment to display content when the feature is enabled or disabled:

```csharp
<Feature Names="@Flags.Offers">
    <Enabled>
        <h2>Offers</h2>
        <ul class="pizza-cards">
            @if (offers != null)
            {
                @foreach (var offer in offers)
                {
                    <li @onclick="@(() => OrderState.ShowConfigurePizzaDialog(offer))" style="background-image: url('@offer.ImageUrl')">
                        <div class="pizza-info">
                            <span class="title">@offer.Name</span>
                            @offer.Description
                            <span class="price">@offer.GetFormattedBasePrice()</span>
                        </div>
                    </li>
                }
            }
        </ul>
    </Enabled>
    <Disabled>
         <span class="title">No offers</span>
    </Disabled>
</Feature>
```

Kind regards!