### PR TITLE
Collapsible radio list component restyling & User details select.

### DIFF
--- a/src/Esquio.UI/ClientApp/src/app/products/flags/toggles/TogglesForm.vue
+++ b/src/Esquio.UI/ClientApp/src/app/products/flags/toggles/TogglesForm.vue
@@ -446,6 +446,7 @@ export default class extends Vue {
         box-shadow: none;
       }
 
+      // stylelint-disable selector-no-qualifying-type
       input[type='radio'] {
         margin-left: 0;
         margin-top: 0;

--- a/src/Esquio.UI/ClientApp/src/app/products/flags/toggles/TogglesForm.vue
+++ b/src/Esquio.UI/ClientApp/src/app/products/flags/toggles/TogglesForm.vue
@@ -446,7 +446,7 @@ export default class extends Vue {
         box-shadow: none;
       }
 
-      input[type="radio"]{
+      input[type='radio'] {
         margin-left: 0;
         margin-top: 0;
       }

--- a/src/Esquio.UI/ClientApp/src/app/products/flags/toggles/TogglesForm.vue
+++ b/src/Esquio.UI/ClientApp/src/app/products/flags/toggles/TogglesForm.vue
@@ -446,8 +446,7 @@ export default class extends Vue {
         box-shadow: none;
       }
 
-      // stylelint-disable selector-no-qualifying-type
-      input[type='radio'] {
+      input {
         margin-left: 0;
         margin-top: 0;
       }

--- a/src/Esquio.UI/ClientApp/src/app/products/flags/toggles/TogglesForm.vue
+++ b/src/Esquio.UI/ClientApp/src/app/products/flags/toggles/TogglesForm.vue
@@ -1,8 +1,8 @@
 <template>
-  <section class="toggles_form container u-container-medium pl-0 pr-0">
-    <div class="row">
+  <article class="toggles_form container u-container-medium pl-0 pr-0">
+    <header>
       <h1>{{$t('toggles.detail')}}</h1>
-    </div>
+    </header>
     <form class="row u-hidden">
       <input-text
         class="toggles_form-group form-group col-md-6 is-disabled"
@@ -18,7 +18,7 @@
     <div
       v-if="accordion && !isEditing"
       id="accordion"
-      class="toggles_form-accordion row"
+      class="toggles_form-accordion"
     >
       <div
         class="toggles_form-card card"
@@ -26,16 +26,17 @@
         :key="key"
       >
         <div class="toggles_form-header card-header">
-          <h5 class="toggles_form-title mb-0">
-            <button
-              class="btn btn-link"
+          <button
+              class="btn toggles_form-action-button"
               data-toggle="collapse"
               :data-target="`#c${i}`"
               aria-expanded="true"
             >
-              {{key}}
-            </button>
-          </h5>
+              <i class="material-icons">add_circle_outline</i>
+          </button>
+          <h2 class="toggles_form-title">
+          {{key}}
+          </h2>
         </div>
 
         <div
@@ -97,6 +98,7 @@
 
     <div
       v-if="paramDetails"
+      class="mt-3 mb-3"
       :class="{'is-disabled': isEditing && isLoading}"
     >
       <div
@@ -104,7 +106,7 @@
         :key="key"
       >
 
-        <h3>{{parameter.name}}</h3>
+        <h4>{{parameter.name}}</h4>
         <p>{{parameter.description}}</p>
 
         <parameter
@@ -131,7 +133,7 @@
         @click="onClickSave"
       />
     </FloatingContainer>
-  </section>
+  </article>
 </template>
 
 <script lang="ts">
@@ -408,46 +410,92 @@ export default class extends Vue {
     padding-left: 0;
   }
 
-  &-button {
-    text-align: left;
+  &-action-button {
+    border-radius: 100%;
+    line-height: 0;
 
-    &.is-active {
-      color: get-color(basic, brightest);
-      background-color: get-color(secondary, bright);
+    &:hover {
+      background-color: transparent;
+      color: get-color(primary, normal);
     }
 
-    &--editing {
-      pointer-events: none;
+    .material-icons {
+      font-size: get-font-size(xl);
+    }
+  }
+
+  .btn-group-vertical {
+    margin: 0;
+  }
+
+  .toggles_form {
+    &-button.btn-outline-secondary {
+      text-align: left;
+      font-size: get-font-size(s);
+      border: 0;
+      padding: .25rem 0;
+      color: get-color(basic, darkest);
+
+      &:active,
+      &.is-active,
+      &:focus,
+      &:hover {
+        background-color: transparent;
+        border: 0;
+        color: get-color(basic, darkest);
+        box-shadow: none;
+      }
+
+      input[type="radio"]{
+        margin-left: 0;
+        margin-top: 0;
+      }
+
+      &--editing {
+        pointer-events: none;
+        background-color: transparent;
+      }
+
+      &.is-active {
+        background-color: transparent;
+      }
     }
   }
 
   &-accordion {
-    border: 1px solid get-color(basic, normal);
     flex-direction: column;
   }
 
   &-card {
     box-shadow: none;
+    margin-bottom: .5rem;
+    background-color: get-color(basic, brighter);
+    min-height: 2.5rem;
+    border-radius: .25rem;
   }
 
   &-header {
-    padding: 0;
+    padding: .75rem .5rem;
+    display: flex;
+    align-items: center;
+    border-bottom: 0;
 
     /deep/ button {
-      &:hover {
-        background-color: get-color(secondary, bright);
-        color: get-color(basic, brightest);
-      }
+      padding: 0;
+      margin: 0;
     }
   }
 
   &-title {
-    margin-left: .5rem;
-    margin-top: .5rem;
+    margin: 0;
+    padding-bottom: 0;
+    margin-left: .25rem;
+    font-size: get-font-size(m);
+    line-height: 1.2rem;
   }
 
   &-body {
-    padding: 0 1.25rem;
+    padding: .25rem 1rem .25rem 2.25rem;
   }
 
   &-friendlyname {

--- a/src/Esquio.UI/ClientApp/src/app/shared/Navigation.vue
+++ b/src/Esquio.UI/ClientApp/src/app/shared/Navigation.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="navigation">
+<header class="navigation">
   <div class="container navigation-container">
     <router-link to="/" class="navigation-title">
       {{$t('common.title')}}
@@ -19,7 +19,7 @@
     </b-dropdown>
     </div>
   </div>
-</div>
+</header>
 </template>
 
 <script lang="ts">

--- a/src/Esquio.UI/ClientApp/src/app/shared/parameters/DateParameter.vue
+++ b/src/Esquio.UI/ClientApp/src/app/shared/parameters/DateParameter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="date_parameter" data-testid="date-parameter">
+  <div class="date_parameter col-12" data-testid="date-parameter">
     <div class="date_parameter-container">
       <div class="date_parameter-column">
         <date-picker

--- a/src/Esquio.UI/ClientApp/src/app/shared/parameters/Parameter.vue
+++ b/src/Esquio.UI/ClientApp/src/app/shared/parameters/Parameter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="parameter">
+  <div class="parameter row">
     <component :is="selectedComponent" :options="options" @change="onChangeParameterValue"></component>
   </div>
 </template>

--- a/src/Esquio.UI/ClientApp/src/app/shared/parameters/PercentageParameter.vue
+++ b/src/Esquio.UI/ClientApp/src/app/shared/parameters/PercentageParameter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="percentage_parameter" data-testid="percentage-parameter">
+  <div class="percentage_parameter col-12" data-testid="percentage-parameter">
     <div class="percentage_parameter-container">
       <div class="percentage_parameter-slider">
         <vue-slider v-model="value" :min="0" :max="100" :tooltip-formatter="formatter"></vue-slider>

--- a/src/Esquio.UI/ClientApp/src/app/shared/parameters/SemicolonParameter.vue
+++ b/src/Esquio.UI/ClientApp/src/app/shared/parameters/SemicolonParameter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="semicolon_parameter" data-testid="semicolon-parameter">
+  <div class="semicolon_parameter col-12" data-testid="semicolon-parameter">
     <vue-tags-input
         ref="input"
         v-model="formParameter"

--- a/src/Esquio.UI/ClientApp/src/app/shared/parameters/StringParameter.vue
+++ b/src/Esquio.UI/ClientApp/src/app/shared/parameters/StringParameter.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="string_parameter" data-testid="string-parameter">
+  <div class="string_parameter col-md-6" data-testid="string-parameter">
     <input-text
-      class="form-group col-md-6"
+      class="form-group"
       v-model="value"
       id="value_name"
       @blur="onBlurInput"

--- a/src/Esquio.UI/ClientApp/src/app/users/UsersForm.vue
+++ b/src/Esquio.UI/ClientApp/src/app/users/UsersForm.vue
@@ -19,7 +19,7 @@
           {{$t('users.placeholders.role')}}
         </label>
         <select
-          class="users_form-select custom-select"
+          class="users_form-select custom-select form-control"
           id="role"
           v-model="role"
         >
@@ -243,7 +243,16 @@ export default class extends Vue {
   }
 
   &-select {
-    padding: .5rem;
+    border: 0;
+    box-shadow: none;
+  }
+
+  .bmd-form-group {
+    padding-top: 1.3rem;
+
+    .bmd-label-floating {
+      top: 0;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Unifying the styles of Esquio interface there was made two changes:

- The  collapsible radio list component  of Toggle Details section has been restyled keeping the Esquio style guide.
<img width="516" alt="2019-10-27 21_01_50-Esquio UI" src="https://user-images.githubusercontent.com/14984918/67669945-29d6a980-f973-11e9-82f6-f6098c5c80b5.png">

- Native select of User Details section was styled using material design styles. This styles are used in other inputs of Esquio interface.
<img width="581" alt="2019-10-27 21_46_59-Esquio UI" src="https://user-images.githubusercontent.com/14984918/67669983-3ce97980-f973-11e9-8230-303a05177582.png">



