### PR TITLE
AddConfigurationStore() is missing when following the Getting Started…

### DIFF
--- a/docs/source/started/aspnetcore.rst
+++ b/docs/source/started/aspnetcore.rst
@@ -10,11 +10,13 @@ Setup
 
 To install Esquio open a console window and type the following command using the .NET Core CLI::
 
+        dotnet add package Esquio.Configuration.Store
         dotnet add package Esquio.AspNetCore
 
 
 or using Powershell or Package Manager::
 
+        Install-Package Esquio.Configuration.Store
         Install-Package Esquio.AspNetCore
 
 or install via NuGet.

--- a/docs/source/started/netcore.rst
+++ b/docs/source/started/netcore.rst
@@ -28,7 +28,7 @@ To install Esquio type the following command::
         dotnet package add Microsoft.Extensions.DependencyInjection
         dotnet package add Microsoft.Extensions.Logging.Console
         dotnet package add Microsoft.Extensions.Configuration.Json
-        dotnet package add Esquio
+        dotnet package add Esquio.Configuration.Store
         dotnet restore
 
 or using Powershell or Package Manager::
@@ -36,7 +36,7 @@ or using Powershell or Package Manager::
         Install-Package Microsoft.Extensions.DependencyInjection
         Install-Package Microsoft.Extensions.Logging.Console
         Install-Package Microsoft.Extensions.Configuration.Json
-        Install-Package Esquio
+        Install-Package Esquio.Configuration.Store
 
 Setup
 ^^^^^


### PR DESCRIPTION
This PR fix the issue #90 because we missed to add some NuGet packages in the "Getting Started"