### PR TITLE
IsInRole support for RoleNameToggle

### DIFF
--- a/demos/WebApp/Controllers/AccountController.cs
+++ b/demos/WebApp/Controllers/AccountController.cs
@@ -21,6 +21,10 @@ namespace WebApp.Controllers
         {
             var identity = new ClaimsIdentity(CookieAuthenticationDefaults.AuthenticationScheme);
             identity.AddClaim(new Claim(ClaimTypes.Name, model.UserName));
+            if (new Random().Next(0, 2) == 0)
+            {
+                identity.AddClaim(new Claim(ClaimTypes.Role, "earlyadopters"));
+            }
 
             var principal = new ClaimsPrincipal(identity);
 

--- a/demos/WebApp/esquio.json
+++ b/demos/WebApp/esquio.json
@@ -14,7 +14,7 @@
             "Enabled": true,
             "Toggles": [
               {
-                "Type": "Esquio.Toggles.GradualRolloutUserNameToggle",
+                "Type": "Esquio.AspNetCore.Toggles.GradualRolloutUserNameToggle, Esquio.AspNetCore",
                 "Parameters": {
                   "Percentage": 92
                 }
@@ -43,7 +43,7 @@
             "Enabled": true,
             "Toggles": [
               {
-                "Type": "Esquio.Toggles.UserNameToggle",
+                "Type": "Esquio.AspNetCore.Toggles.UserNameToggle, Esquio.AspNetCore",
                 "Parameters": {
                   "Users": "betauser;beta"
                 }
@@ -55,9 +55,9 @@
             "Enabled": true,
             "Toggles": [
               {
-                "Type": "Esquio.Toggles.UserNameToggle",
+                "Type": "Esquio.AspNetCore.Toggles.RoleNameToggle, Esquio.AspNetCore",
                 "Parameters": {
-                  "Users": "alphauser;alpha"
+                  "Roles": "alphausers;earlyadopters"
                 }
               }
             ]

--- a/samples/GettingStarted.AspNetCore.ClientEndpoint/Program.cs
+++ b/samples/GettingStarted.AspNetCore.ClientEndpoint/Program.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace GettingStarted.AspNetCore.Intro
 {

--- a/samples/GettingStarted.AspNetCore.Intro/Program.cs
+++ b/samples/GettingStarted.AspNetCore.Intro/Program.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace GettingStarted.AspNetCore.Intro
 {

--- a/samples/GettingStarted.AspNetCore.IntroOptions/Program.cs
+++ b/samples/GettingStarted.AspNetCore.IntroOptions/Program.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace GettingStarted.AspNetCore.IntroOptions
 {

--- a/samples/GettingStarted.AspNetCore.Mvc.HttpStore/Controllers/HomeController.cs
+++ b/samples/GettingStarted.AspNetCore.Mvc.HttpStore/Controllers/HomeController.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using GettingStarted.AspNetCore.Mvc.Models;

--- a/samples/GettingStarted.AspNetCore.Mvc.HttpStore/Models/ErrorViewModel.cs
+++ b/samples/GettingStarted.AspNetCore.Mvc.HttpStore/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GettingStarted.AspNetCore.Mvc.Models
 {
     public class ErrorViewModel

--- a/samples/GettingStarted.AspNetCore.Mvc.HttpStore/Program.cs
+++ b/samples/GettingStarted.AspNetCore.Mvc.HttpStore/Program.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace GettingStarted.AspNetCore.Mvc
 {

--- a/samples/GettingStarted.AspNetCore.Mvc/Controllers/HomeController.cs
+++ b/samples/GettingStarted.AspNetCore.Mvc/Controllers/HomeController.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using GettingStarted.AspNetCore.Mvc.Models;

--- a/samples/GettingStarted.AspNetCore.Mvc/Models/ErrorViewModel.cs
+++ b/samples/GettingStarted.AspNetCore.Mvc/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GettingStarted.AspNetCore.Mvc.Models
 {
     public class ErrorViewModel

--- a/samples/GettingStarted.AspNetCore.Mvc/Program.cs
+++ b/samples/GettingStarted.AspNetCore.Mvc/Program.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace GettingStarted.AspNetCore.Mvc
 {

--- a/samples/GettingStarted.AspNetCore.Mvc/Startup.cs
+++ b/samples/GettingStarted.AspNetCore.Mvc/Startup.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/samples/GettingStarted.AspNetCore.Toggles/Controllers/HomeController.cs
+++ b/samples/GettingStarted.AspNetCore.Toggles/Controllers/HomeController.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using GettingStarted.AspNetCore.Toggles.Models;

--- a/samples/GettingStarted.AspNetCore.Toggles/Models/ErrorViewModel.cs
+++ b/samples/GettingStarted.AspNetCore.Toggles/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace GettingStarted.AspNetCore.Toggles.Models
 {
     public class ErrorViewModel

--- a/samples/GettingStarted.AspNetCore.Toggles/Program.cs
+++ b/samples/GettingStarted.AspNetCore.Toggles/Program.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace GettingStarted.AspNetCore.Toggles
 {

--- a/samples/GettingStarted.AspNetCore.Toggles/Startup.cs
+++ b/samples/GettingStarted.AspNetCore.Toggles/Startup.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/samples/GettingStarted.Blazor.WebAssembly/Client/Program.cs
+++ b/samples/GettingStarted.Blazor.WebAssembly/Client/Program.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Text;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/samples/GettingStarted.Blazor.WebAssembly/Server/Controllers/WeatherForecastController.cs
+++ b/samples/GettingStarted.Blazor.WebAssembly/Server/Controllers/WeatherForecastController.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 

--- a/samples/GettingStarted.Blazor.WebAssembly/Server/Pages/Error.cshtml.cs
+++ b/samples/GettingStarted.Blazor.WebAssembly/Server/Pages/Error.cshtml.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;

--- a/samples/GettingStarted.Blazor.WebAssembly/Server/Program.cs
+++ b/samples/GettingStarted.Blazor.WebAssembly/Server/Program.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace GettingStarted.Blazor.WebAssembly.Server
 {

--- a/samples/GettingStarted.Blazor.WebAssembly/Server/Startup.cs
+++ b/samples/GettingStarted.Blazor.WebAssembly/Server/Startup.cs
@@ -1,11 +1,8 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System.Linq;
 
 namespace GettingStarted.Blazor.WebAssembly.Server
 {

--- a/src/Esquio.AspNetCore/Endpoints/Metadata/FeatureFilter.cs
+++ b/src/Esquio.AspNetCore/Endpoints/Metadata/FeatureFilter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Esquio.AspNetCore.Endpoints.Metadata
 {

--- a/src/Esquio.AspNetCore/Endpoints/Metadata/IFeatureFilterMetadata.cs
+++ b/src/Esquio.AspNetCore/Endpoints/Metadata/IFeatureFilterMetadata.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esquio.AspNetCore.Endpoints.Metadata
+﻿namespace Esquio.AspNetCore.Endpoints.Metadata
 {
     internal interface IFeatureFilterMetadata
     {

--- a/src/Esquio.Http.Store/DependencyInjection/IHttpClientBuilderExtensions.cs
+++ b/src/Esquio.Http.Store/DependencyInjection/IHttpClientBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using System.Net.Http;
+﻿using System.Net.Http;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Esquio.UI.Api.Shared/Models/Permissions/My/MyResponse.cs
+++ b/src/Esquio.UI.Api.Shared/Models/Permissions/My/MyResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Esquio.UI.Api.Shared.Models.Permissions.My
+﻿namespace Esquio.UI.Api.Shared.Models.Permissions.My
 {
     public class MyResponse
     {

--- a/src/Esquio.UI.Api/Infrastructure/Authorization/PolicyRequirement.cs
+++ b/src/Esquio.UI.Api/Infrastructure/Authorization/PolicyRequirement.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using System;
-using System.Security.Claims;
 
 namespace Esquio.UI.Api.Infrastructure.Authorization
 {

--- a/src/Esquio.UI.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Esquio.UI.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using Esquio.UI.Api;
-using Esquio.UI.Api.Infrastructure.Data.DbContexts;
-using Esquio.UI.Api.Infrastructure.Data.Options;
 using Hellang.Middleware.ProblemDetails;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Esquio.UI.Api/Scenarios/ApiKeys/Details/DetailsApiKeyRequestHandler.cs
+++ b/src/Esquio.UI.Api/Scenarios/ApiKeys/Details/DetailsApiKeyRequestHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Esquio.UI.Api.Infrastructure.Data.DbContexts;
-using Esquio.UI.Api.Infrastructure.Data.Entities;
 using Esquio.UI.Api.Shared.Models.ApiKeys.Details;
 using MediatR;
 using Microsoft.EntityFrameworkCore;

--- a/src/Esquio.UI.Client/Services/EsquioHttpClient.cs
+++ b/src/Esquio.UI.Client/Services/EsquioHttpClient.cs
@@ -27,7 +27,6 @@ using Esquio.UI.Api.Shared.Models.Toggles.AddParameter;
 using Esquio.UI.Api.Shared.Models.Toggles.Details;
 using Esquio.UI.Api.Shared.Models.Toggles.KnownTypes;
 using Esquio.UI.Api.Shared.Models.Toggles.Reveal;
-using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Newtonsoft.Json;
 using Serilog;
 using System;

--- a/src/Esquio.UI.Client/Services/LocalStorage.cs
+++ b/src/Esquio.UI.Client/Services/LocalStorage.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.JSInterop;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using Serilog;
 using System;
 
 namespace Esquio.UI.Client.Services

--- a/src/Esquio/Abstractions/IToggle.cs
+++ b/src/Esquio/Abstractions/IToggle.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Esquio.Abstractions

--- a/tests/FunctionalTests/Esquio.UI.Api/Scenarios/ApiKeys/ApiKeysControllerTests.cs
+++ b/tests/FunctionalTests/Esquio.UI.Api/Scenarios/ApiKeys/ApiKeysControllerTests.cs
@@ -1,7 +1,4 @@
 ﻿using Esquio.UI.Api.Infrastructure.Data.Entities;
-using Esquio.UI.Api.Scenarios.ApiKeys.Add;
-using Esquio.UI.Api.Scenarios.ApiKeys.Details;
-using Esquio.UI.Api.Scenarios.ApiKeys.List;
 using Esquio.UI.Api.Shared.Models;
 using Esquio.UI.Api.Shared.Models.ApiKeys.Add;
 using Esquio.UI.Api.Shared.Models.ApiKeys.Details;

--- a/tests/UnitTests/Esquio.AspNetCore/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/tests/UnitTests/Esquio.AspNetCore/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace UnitTests.Esquio.AspNetCore.Extensions

--- a/tests/UnitTests/Esquio.AspNetCore/Toggles/RoleNameToggleTests.cs
+++ b/tests/UnitTests/Esquio.AspNetCore/Toggles/RoleNameToggleTests.cs
@@ -117,7 +117,7 @@ namespace UnitTests.Esquio.AspNetCore.Toggles
         }
 
         [Fact]
-        public async Task be_active_if_role_is_equal_non_sensitive_to_roles_parameters_value()
+        public async Task be_not_active_if_role_is_not_equal_case_sensitive_to_roles_parameters_value()
         {
             var toggle = Build
                 .Toggle<RoleNameToggle>()
@@ -143,7 +143,7 @@ namespace UnitTests.Esquio.AspNetCore.Toggles
                    EsquioConstants.DEFAULT_RING_NAME,
                    toggle));
 
-            active.Should().BeTrue();
+            active.Should().BeFalse();
         }
 
         [Fact]
@@ -163,6 +163,37 @@ namespace UnitTests.Esquio.AspNetCore.Toggles
 
             context.User = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[] { new Claim(ClaimsIdentity.DefaultRoleClaimType, "admin") }, "cookies"));
+
+            var contextAccessor = new FakeHttpContextAccessor(context);
+
+            var active = await new RoleNameToggle(contextAccessor).IsActiveAsync(
+               ToggleExecutionContext.FromToggle(
+                   feature.Name,
+                   EsquioConstants.DEFAULT_PRODUCT_NAME,
+                   EsquioConstants.DEFAULT_RING_NAME,
+                   toggle));
+
+            active.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task be_active_when_role_type_is_different_from_default_role_type()
+        {
+            var toggle = Build
+                .Toggle<RoleNameToggle>()
+                .AddOneParameter(Roles, "admin")
+                .Build();
+
+            var feature = Build
+                .Feature(Constants.FeatureName)
+                .AddOne(toggle)
+                .Build();
+
+            var context = new DefaultHttpContext();
+
+            context.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    new Claim[] { new Claim("role", "admin") }, "cookies", nameType: "name", roleType: "role" ));
 
             var contextAccessor = new FakeHttpContextAccessor(context);
 

--- a/tests/UnitTests/Esquio/Toggles/EnvironmentVariableToggleTests.cs
+++ b/tests/UnitTests/Esquio/Toggles/EnvironmentVariableToggleTests.cs
@@ -5,7 +5,6 @@ using FluentAssertions;
 using System;
 using System.Threading.Tasks;
 using UnitTests.Builders;
-using UnitTests.Seedwork;
 using Xunit;
 
 namespace UnitTests.Esquio.Toggles

--- a/tests/UnitTests/Esquio/Toggles/FromToToggleTests.cs
+++ b/tests/UnitTests/Esquio/Toggles/FromToToggleTests.cs
@@ -5,7 +5,6 @@ using FluentAssertions;
 using System;
 using System.Threading.Tasks;
 using UnitTests.Builders;
-using UnitTests.Seedwork;
 using Xunit;
 namespace UnitTests.Esquio.Toggles
 {

--- a/tests/UnitTests/Seedwork/FakeHostEnvironment.cs
+++ b/tests/UnitTests/Seedwork/FakeHostEnvironment.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
-using System;
 
 namespace UnitTests.Seedwork
 {


### PR DESCRIPTION
### What this PR does / why we need it:

This PR modify the RoleNameToggle in order to decide if the user belongs to a role using User.IsInRole method instead look for a claim and reduce the complexity because the user doesn't care about the RoleType (No configuration needed).

Please make sure you've completed the relevant tasks for this PR, out of the following list:

 - [X] Code compiles correctly
 - [X] Created/updated tests
 - [X] Unit tests passing
 - [X] End-to-end tests passing
 - [ ] Add documentation (No needed)
 - [X] Provided sample for the feature