### PR TITLE
feat(props): move common metadata to build.directory.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,17 @@
 ﻿<Project>
   <Import Project="build/dependencies.props" />
+  <PropertyGroup Label="Package information">
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>http://github.com/xabaril/Esquio</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/xabaril/Esquio</RepositoryUrl>
+    <Authors>Xabaril Contributors</Authors>
+    <Company>Xabaril</Company>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>true;</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,19 +7,6 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Label="Package information">
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>http://github.com/xabaril/Esquio</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/xabaril/Esquio</RepositoryUrl>
-    <Authors>Xabaril Contributors</Authors>
-    <Company>Xabaril</Company>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>true;</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
-
   <PropertyGroup Label="Esquio Versions">
     <esquio>3.0.0$(VersionSuffix)</esquio>
     <esquioaspnetcore>3.0.0$(VersionSuffix)</esquioaspnetcore>


### PR DESCRIPTION
### What this PR does / why we need it:

This PR move the common metadata from **dependencies.props** to the **Directory.Build.props**

Please make sure you've completed the relevant tasks for this PR, out of the following list:

 - [X] Code compiles correctly
 - [X] Created/updated tests
 - [X] Unit tests passing
 - [X] End-to-end tests passing
 - [ ] Add documentation (No needed)
 - [ ] Provided sample for the feature (No needed)