### PR TITLE
parameters --name parameter typo

### DIFF
--- a/tools/Esquio.CliTool/Command/ParametersCommand.cs
+++ b/tools/Esquio.CliTool/Command/ParametersCommand.cs
@@ -36,7 +36,7 @@ namespace Esquio.CliTool.Command
             [Required]
             public string ToggleType { get; set; }
 
-            [Option("--name <NAME>", Description = "The parameter value.")]
+            [Option("--name <NAME>", Description = "The parameter name.")]
             [Required]
             public string ParameterName { get; set; }
 


### PR DESCRIPTION
Greetings! there's a typo in the description parameters --name parameter, description is "The parameter value." and should be "The parameter name."