### PR TITLE
Add info for temporary demo env to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Documentation Status](https://readthedocs.org/projects/esquio/badge/?version=latest)](https://esquio.readthedocs.io/en/latest/?badge=latest)
 
+[![Blimp demo badge](https://kelda.io/demo-badge.svg?repo=https://github.com/Xabaril/Esquio)](https://kelda.io/preview-env/?repo=https://github.com/Xabaril/Esquio&port=app:80&port=ui:80&composeFiles=build/docker-compose-demo-with-ui-sqlserver-with-reference-images.yml)
 
 ## About [Esquio](https://esquio.readthedocs.io) 
 
@@ -21,6 +22,15 @@ Maintained by [awesome community contributors](https://github.com/Xabaril/Esquio
 
 
 For project documentation, please visit [readthedocs](https://esquio.readthedocs.io).
+
+
+## Temporary demo environment
+
+If you want to play around with Esquio without running it locally, you can [boot a personal demo copy](https://kelda.io/preview-env/?repo=https://github.com/Xabaril/Esquio&port=app:80&port=ui:80&composeFiles=build/docker-compose-demo-with-ui-sqlserver-with-reference-images.yml) from your browser without downloading or setting up anything.
+
+Clicking the [link](https://kelda.io/preview-env/?repo=https://github.com/Xabaril/Esquio&port=app:80&port=ui:80&composeFiles=build/docker-compose-demo-with-ui-sqlserver-with-reference-images.yml) boots this repo in the Blimp cloud, and creates a public URL for you to access it.
+
+To use the demo, you can follow along with [this presentation at the ASP.NET Community Standup](https://www.youtube.com/watch?v=qotnVlgYd8c&t=1093). You can skip the docker-compose step and simply use the "Connect" buttons in the sandbox to access the demo app and the Esquio UI.
 
 ## How to build
 Esquio is built against the latest NET Core 3.


### PR DESCRIPTION
Hi @unaizorrilla, @kklin had opened #166 a little bit ago for adding a in-browser demo to the README. We've updated some things on our end to support Esquio. Using the new docker-compose.yml it seems to work quite nicely:

![esquio-sandbox](https://user-images.githubusercontent.com/1581504/94200691-a87fe380-fe6f-11ea-984f-2ebbaf3d3b43.png)

Here's [the link to boot the sandbox](https://kelda.io/preview-env/?repo=https://github.com/Xabaril/Esquio&port=app:80&port=ui:80&composeFiles=build/docker-compose-demo-with-ui-sqlserver-with-reference-images.yml) that is used in the PR.

What do you think?