### PR TITLE
Bump Microsoft.Data.SqlClient to 2.1.2 for Managed Identities support

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -41,7 +41,7 @@
     <PackageReference Update="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
     <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0" />
     <PackageReference Update="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.2" />
-	<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.2" />
+    <PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.2" />
 
     
     <PackageReference Update="System.Text.Json" Version="5.0.0" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -41,6 +41,7 @@
     <PackageReference Update="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
     <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0" />
     <PackageReference Update="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.2" />
+	<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.2" />
 
     
     <PackageReference Update="System.Text.Json" Version="5.0.0" />

--- a/src/Esquio.UI.Api/Esquio.UI.Api.csproj
+++ b/src/Esquio.UI.Api/Esquio.UI.Api.csproj
@@ -31,7 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
 
   </ItemGroup>
 

--- a/src/Esquio.UI.Api/Esquio.UI.Api.csproj
+++ b/src/Esquio.UI.Api/Esquio.UI.Api.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />

--- a/src/Esquio.UI.Api/Esquio.UI.Api.csproj
+++ b/src/Esquio.UI.Api/Esquio.UI.Api.csproj
@@ -30,6 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+	<PackageReference Include="Microsoft.Data.SqlClient" />
 
   </ItemGroup>
 


### PR DESCRIPTION
Bumping _Microsoft.Data.SqlClient_ to 2.1.2 so we are able to use Azure Managed Identities automatically via Connection String. Installing JSON.NET on _Esquio.UI.Api_ as we no longer have it on the SqlClient dependency tree.