### PR TITLE
Add Esquio.UI.Deployment to ease UI deployment

### DIFF
--- a/Esquio.sln
+++ b/Esquio.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28729.10
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31825.309
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{8303C07B-6EC4-419C-9193-E4F6EDE57150}"
 EndProject
@@ -76,6 +76,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GettingStarted.AspNetCore.EvaluationSession", "samples\GettingStarted.AspNetCore.EvaluationSession\GettingStarted.AspNetCore.EvaluationSession.csproj", "{78B00EDF-CC4F-4014-BCEA-6807CB66FB2C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GettingStarted.AspNetCore.Mvc.ApplicationInsights", "samples\GettingStarted.AspNetCore.Mvc.ApplicationInsights\GettingStarted.AspNetCore.Mvc.ApplicationInsights.csproj", "{66B38F31-F08A-4A66-BB5E-417594478003}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esquio.UI.Deployment", "src\Esquio.UI.Deployment\Esquio.UI.Deployment.csproj", "{11485EC6-1B15-471F-9647-FED6C1905962}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esquio.UI.Web", "demos\Esquio.UI.Web\Esquio.UI.Web.csproj", "{03DF967C-6AF5-4970-AE15-09CA05E6B77A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -195,6 +199,14 @@ Global
 		{66B38F31-F08A-4A66-BB5E-417594478003}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66B38F31-F08A-4A66-BB5E-417594478003}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66B38F31-F08A-4A66-BB5E-417594478003}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11485EC6-1B15-471F-9647-FED6C1905962}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11485EC6-1B15-471F-9647-FED6C1905962}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11485EC6-1B15-471F-9647-FED6C1905962}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11485EC6-1B15-471F-9647-FED6C1905962}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03DF967C-6AF5-4970-AE15-09CA05E6B77A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03DF967C-6AF5-4970-AE15-09CA05E6B77A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03DF967C-6AF5-4970-AE15-09CA05E6B77A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03DF967C-6AF5-4970-AE15-09CA05E6B77A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -228,6 +240,8 @@ Global
 		{C398E2E1-3000-4FD2-8624-6963C8ECEA3B} = {29B9FABC-D65A-4635-A2A6-458AE458C251}
 		{78B00EDF-CC4F-4014-BCEA-6807CB66FB2C} = {29B9FABC-D65A-4635-A2A6-458AE458C251}
 		{66B38F31-F08A-4A66-BB5E-417594478003} = {29B9FABC-D65A-4635-A2A6-458AE458C251}
+		{11485EC6-1B15-471F-9647-FED6C1905962} = {FA3A9027-8210-4ECE-8075-28EE8C481412}
+		{03DF967C-6AF5-4970-AE15-09CA05E6B77A} = {669FB673-7855-4B59-9625-132124AB65A4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {012ABB24-4701-4BF2-9577-7619D3BAD62A}

--- a/demos/Esquio.UI.Web/Esquio.UI.Web.csproj
+++ b/demos/Esquio.UI.Web/Esquio.UI.Web.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UserSecretsId>Esquio.UI.Web-3fa21dad-5056-4803-90e3-58c69123dcaa</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Esquio.UI.Deployment\Esquio.UI.Deployment.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/demos/Esquio.UI.Web/Program.cs
+++ b/demos/Esquio.UI.Web/Program.cs
@@ -1,0 +1,32 @@
+using Esquio.UI.Deployment.Setup;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Esquio.UI.Web
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder
+                        .ConfigureServices((context, services) =>
+                        {
+                            services.AddEsquioServices(context.Configuration, context.HostingEnvironment);
+                        })
+                        .Configure((context, app) =>
+                        {
+                            var apiVersion = app.ApplicationServices.GetRequiredService<IApiVersionDescriptionProvider>();
+                            app.ConfigureEsquio(context.Configuration, context.HostingEnvironment, apiVersion);
+                        });
+                });
+    }
+}

--- a/demos/Esquio.UI.Web/appsettings.Development.json
+++ b/demos/Esquio.UI.Web/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/demos/Esquio.UI.Web/appsettings.json
+++ b/demos/Esquio.UI.Web/appsettings.json
@@ -1,0 +1,58 @@
+{
+  "ApplicationInsights": {
+    "InstrumentationKey": "00000000-0000-0000-0000-000000000000"
+  },
+  "Serilog": {
+    "MinimumLevel": "Information",
+    "WriteTo": [
+      {
+        "Name": "ApplicationInsights",
+        "Args": {
+          "telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+        }
+      },
+      {
+        "Name": "ColoredConsole",
+        "Args": {
+          "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level} {MachineName} {SourceContext} {Message} {Exception} {NewLine}"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext" ],
+    "Properties": {
+      "Application": "Esquio-UI"
+    }
+  },
+  "AllowedHosts": "*",
+  "Cors": {
+    "Origins": "*" // allowed origins for cors separated by , character use '*' to allow all origins
+  },
+  "Security": {
+    "DefaultUsers": [
+      {
+        "ApplicationRole": "Management",
+        "SubjectId": "1" // Alice with demo.identityserver.io
+      },
+      {
+        "ApplicationRole": "Management",
+        "SubjectId": "2" // bob with demo.identityserver.io
+      }
+    ],
+    "IsAzureAd": false,
+    "OpenId": {
+      "ClientId": "interactive.public",
+      "Audience": "api",
+      "Scope": "api",
+      "Authority": "https://demo.identityserver.io/",
+      "ResponseType": "code"
+    }
+  },
+  "Data": {
+    "Store": "SqlServer",
+    "ConnectionString": "Server=tcp:localhost,5433;Initial Catalog=Esquio.UI;User Id=sa;Password=Password12!"
+    //"Store": "MySql",
+    //"ConnectionString": "Server=localhost;Database=Esquio.UI.Tests;Uid=root;Pwd=Password12!"
+    //"Store": "NpgSql",
+    //"ConnectionString": "Host=localhost;Port=5434;Database=Esquio.UI.Tests;User Id=postgres;Password=Password12!"
+  }
+}

--- a/src/Esquio.UI.Deployment/Esquio.UI.Deployment.csproj
+++ b/src/Esquio.UI.Deployment/Esquio.UI.Deployment.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreTargetVersion)</TargetFramework>
+    <Description>Esquio UI deployment package</Description>
+    <PackageTags>Esquio;Features;Flags;Toggles;AB Testing;AspNetCore;Deployment</PackageTags>
+    <Version>$(esquioaspnetcore)</Version>
+    <PackageId>Esquio.UI.Deployment</PackageId>
+    <PackageVersion>$(esquioaspnetcore)</PackageVersion>
+    <LangVersion>$(LangVersion)</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="IdentityModel" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
+
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Esquio.AspNetCore\Esquio.AspNetCore.csproj" />
+    <ProjectReference Include="..\Esquio.UI.Api\Esquio.UI.Api.csproj" />
+    <ProjectReference Include="..\Esquio.UI.Client\Esquio.UI.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Esquio.UI.Deployment/Infrastructure/Data/Seed/StoreDbContextSeed.cs
+++ b/src/Esquio.UI.Deployment/Infrastructure/Data/Seed/StoreDbContextSeed.cs
@@ -1,0 +1,54 @@
+﻿using Esquio.UI.Api.Infrastructure.Data.DbContexts;
+using Esquio.UI.Api.Infrastructure.Data.Entities;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Esquio.UI.Deployment.Infrastructure.Data.Seed
+{
+    public static class StoreDbContextSeed
+    {
+        public static Action<StoreDbContext, IServiceProvider> Seed()
+        {
+            const string DEFAULT_USERS = "Security:DefaultUsers";
+            const string DEFAULT_API_KEY = "ZgZ9/qcwJGe/Utefuym5YS/84mE8/9x7kIrx2V/aIxc=";
+
+            return (context, sp) =>
+            {
+                if (!context.Permissions.Any())
+                {
+                    var configuration = sp.GetRequiredService<IConfiguration>();
+
+                    context.ApiKeys.Add(
+                        new ApiKeyEntity("demo", DEFAULT_API_KEY, DateTime.UtcNow.AddYears(1)));
+
+                    var defaultUsers = new List<PermissionEntity>();
+
+                    foreach (var section in configuration.GetSection(DEFAULT_USERS)?.GetChildren())
+                    {
+                        var entity = new PermissionEntity {
+                            Kind = SubjectType.User
+                        };
+
+                        section.Bind(entity);
+
+                        defaultUsers.Add(entity);
+                    }
+
+                    var apiKeyPermission = new PermissionEntity() {
+                        SubjectId = DEFAULT_API_KEY,
+                        ApplicationRole = ApplicationRole.Reader,
+                        Kind = SubjectType.Application
+                    };
+
+                    defaultUsers.Add(apiKeyPermission);
+
+                    context.Permissions.AddRange(defaultUsers);
+                    context.SaveChanges();
+                }
+            };
+        }
+    }
+}

--- a/src/Esquio.UI.Deployment/Infrastructure/Extensions/ApiBuilderExtensions.cs
+++ b/src/Esquio.UI.Deployment/Infrastructure/Extensions/ApiBuilderExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Esquio.UI.Deployment.Infrastructure.Middleware;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    public static class ApiBuilderExtensions
+    {
+        public static IApplicationBuilder AddClientBlazorConfiguration(this IApplicationBuilder appBuilder)
+        {
+            return appBuilder.UseMiddleware<BlazorClientConfigurationMiddleware>();
+        }
+    }
+}

--- a/src/Esquio.UI.Deployment/Infrastructure/Extensions/IHostExtensions.cs
+++ b/src/Esquio.UI.Deployment/Infrastructure/Extensions/IHostExtensions.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    static class IHostExtensions
+    {
+        public static IHost MigrateDbContext<TContext>(this IHost host, Action<TContext, IServiceProvider> seeder = null)
+            where TContext : DbContext
+        {
+            using (var scope = host.Services.CreateScope())
+            {
+                var context = scope.ServiceProvider.GetService<TContext>();
+
+                try
+                {
+                    context.Database.Migrate();
+
+                    seeder?.Invoke(context, scope.ServiceProvider);
+                }
+                catch (Exception ex)
+                {
+                    var logger = scope.ServiceProvider.GetRequiredService<ILogger<TContext>>();
+
+                    logger.LogError(ex, $"An error occurred while migrating the database for context {nameof(TContext)}.");
+                }
+            }
+
+            return host;
+        }
+    }
+}

--- a/src/Esquio.UI.Deployment/Infrastructure/Middleware/BlazorClientSettingsMiddleware.cs
+++ b/src/Esquio.UI.Deployment/Infrastructure/Middleware/BlazorClientSettingsMiddleware.cs
@@ -1,0 +1,49 @@
+﻿using Esquio.UI.Api.Infrastructure.Settings;
+using Esquio.UI.Api.Shared.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using System;
+using System.Net.Mime;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Esquio.UI.Deployment.Infrastructure.Middleware
+{
+    internal class BlazorClientConfigurationMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public BlazorClientConfigurationMiddleware(RequestDelegate next)
+        {
+            _next = next ?? throw new ArgumentException(nameof(next));
+        }
+
+        public async Task InvokeAsync(HttpContext context, IOptions<SecuritySettings> settings)
+        {
+            if (context.Request.Path.StartsWithSegments(new PathString("/appsettings.json")))
+            {
+                var securityOptions = new BlazorClientSettings();
+
+                securityOptions.Security = new ClientOpenIdSecurity() {
+                    IsAzureAd = settings.Value.IsAzureAd,
+                    ClientId = settings.Value.OpenId.ClientId,
+                    Authority = settings.Value.OpenId.Authority,
+                    Scope = settings.Value.OpenId.Scope,
+                    Audience = settings.Value.OpenId.Audience,
+                    ResponseType = settings.Value.OpenId.ResponseType,
+                };
+
+                context.Response.ContentType = MediaTypeNames.Application.Json;
+
+                var aa = JsonSerializer.Serialize(securityOptions);
+
+                await context.Response.WriteAsync(
+                    JsonSerializer.Serialize(securityOptions));
+
+                return;
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/src/Esquio.UI.Deployment/Infrastructure/OpenApi/AuthorizeOperationFilter.cs
+++ b/src/Esquio.UI.Deployment/Infrastructure/OpenApi/AuthorizeOperationFilter.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Esquio.UI.Deployment.Infrastructure.OpenApi
+{
+    class AuthorizeOperationFilter
+        : IOperationFilter
+    {
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+#pragma warning disable CS0618
+
+            var hasAuthorize = context.ApiDescription.CustomAttributes().OfType<AuthorizeAttribute>().Any() ||
+                               context.ApiDescription.CustomAttributes().OfType<AuthorizeAttribute>().Any();
+#pragma warning restore 
+
+            if (hasAuthorize)
+            {
+                operation.Security = new List<OpenApiSecurityRequirement>();
+
+                var oauth2SecurityScheme = new OpenApiSecurityScheme() {
+                    Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" },
+                };
+
+                var apiKeySecurityScheme = new OpenApiSecurityScheme() {
+                    Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "apikey" },
+                };
+
+                operation.Security.Add(new OpenApiSecurityRequirement() {
+                    [oauth2SecurityScheme] = new[] { "oauth2" },
+                    [apiKeySecurityScheme] = new[] { "apikey" }
+                });
+            }
+        }
+    }
+}

--- a/src/Esquio.UI.Deployment/Infrastructure/OpenApi/ConfigureSwaggerGenOptions.cs
+++ b/src/Esquio.UI.Deployment/Infrastructure/OpenApi/ConfigureSwaggerGenOptions.cs
@@ -1,0 +1,114 @@
+﻿using Esquio.UI.Api.Infrastructure.Settings;
+using IdentityModel.Client;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Esquio.UI.Deployment.Infrastructure.OpenApi
+{
+    public class ConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
+    {
+        private readonly IApiVersionDescriptionProvider _apiVersion;
+        private readonly IConfiguration _configuration;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public ConfigureSwaggerGenOptions(
+            IConfiguration configuration,
+            IApiVersionDescriptionProvider apiVersion,
+            IHttpClientFactory httpClientFactory)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _apiVersion = apiVersion ?? throw new ArgumentNullException(nameof(apiVersion));
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        }
+
+        public void Configure(SwaggerGenOptions options)
+        {
+            var securitySettings = new SecuritySettings();
+            _configuration.Bind("Security", securitySettings);
+
+            var discoveryDocument = GetDiscoveryDocument(securitySettings);
+
+            options.OperationFilter<AuthorizeOperationFilter>();
+
+            options.DescribeAllParametersInCamelCase();
+            options.CustomSchemaIds(x => x.FullName);
+
+            foreach (var description in _apiVersion.ApiVersionDescriptions)
+            {
+                options.SwaggerDoc(description.GroupName, CreateOpenApiInfoForApiVersion(description));
+            }
+
+            options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme {
+                Type = SecuritySchemeType.OAuth2,
+                Flows = new OpenApiOAuthFlows {
+                    AuthorizationCode = new OpenApiOAuthFlow {
+                        AuthorizationUrl = new Uri(discoveryDocument.AuthorizeEndpoint),
+                        TokenUrl = new Uri(discoveryDocument.TokenEndpoint),
+                        Scopes = new Dictionary<string, string>
+                        {
+                            { securitySettings.OpenId.Scope , "Esquio UI HTTP API" }
+                        },
+                    }
+                },
+                Description = "Esquio UI OpenId Security Scheme"
+            });
+
+            options.AddSecurityDefinition("apikey", new OpenApiSecurityScheme {
+                Type = SecuritySchemeType.ApiKey,
+                Name = "X-Api-Key",
+                In = ParameterLocation.Header,
+                Description = "Esquio UI Api Key Security Scheme"
+            });
+        }
+
+        private static OpenApiInfo CreateOpenApiInfoForApiVersion(ApiVersionDescription description)
+        {
+            var info = new OpenApiInfo() {
+                Title = "Esquio UI API",
+                Version = description.ApiVersion.ToString(),
+                Description = "Esquio UI API",
+                Contact = new OpenApiContact() { Name = "Xabaril", Url = new Uri("https://github.com/Xabaril") },
+                License = new OpenApiLicense()
+            };
+
+            if (description.IsDeprecated)
+            {
+                info.Description += " This API version has been deprecated.";
+            }
+
+            return info;
+        }
+
+        private DiscoveryDocumentResponse GetDiscoveryDocument(SecuritySettings settings)
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+
+            var authority = settings.OpenId.Authority;
+
+            if (settings.IsAzureAd)
+            {
+                authority = $"{settings.OpenId.Authority}/v2.0";
+            }
+
+            var request = new DiscoveryDocumentRequest() {
+                Address = authority,
+                Policy = new DiscoveryPolicy() {
+                    ValidateEndpoints = settings.IsAzureAd ? false : true
+                }
+            };
+            var discoveryDocument = httpClient.GetDiscoveryDocumentAsync(request)
+                .GetAwaiter()
+                .GetResult();
+
+            return discoveryDocument;
+        }
+
+    }
+}

--- a/src/Esquio.UI.Deployment/Infrastructure/Services/DiscoverToggleTypesService.cs
+++ b/src/Esquio.UI.Deployment/Infrastructure/Services/DiscoverToggleTypesService.cs
@@ -1,0 +1,37 @@
+﻿using Esquio.Abstractions;
+using Esquio.UI.Api.Infrastructure.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Esquio.UI.Deployment.Infrastructure.Services
+{
+    public class DiscoverToggleTypesService
+        : IDiscoverToggleTypesService
+    {
+        private static IEnumerable<Type> _typesCache;
+
+        public IEnumerable<Type> Scan()
+        {
+            if (_typesCache is null)
+            {
+                _typesCache = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .Intersect(IntrospectionAssemblies)
+                    .SelectMany(a => a.GetExportedTypes())
+                    .Where(type => typeof(IToggle).IsAssignableFrom(type) && type.IsClass);
+            }
+
+            return _typesCache;
+        }
+
+        private static IEnumerable<Assembly> IntrospectionAssemblies = new Assembly[]
+        {
+            //out-of-box
+            typeof(Toggles.FromToToggle).Assembly,
+            typeof(AspNetCore.Toggles.ClaimValueToggle).Assembly
+            //<--- add your custom toggle assemblies here!
+        };
+    }
+}

--- a/src/Esquio.UI.Deployment/Setup/EsquioApplicationBuilderExtensions.cs
+++ b/src/Esquio.UI.Deployment/Setup/EsquioApplicationBuilderExtensions.cs
@@ -1,0 +1,68 @@
+﻿using Esquio.UI.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Esquio.UI.Deployment.Setup
+{
+    public static class EsquioApplicationBuilderExtensions
+    {
+        public static IApplicationBuilder ConfigureEsquio(this
+            IApplicationBuilder app, 
+            IConfiguration configuration, 
+            IWebHostEnvironment environment, 
+            IApiVersionDescriptionProvider apiVersion)
+        {
+            EsquioUIApiConfiguration.Configure(app,
+                preConfigure: appBuilder =>
+                {
+                    appBuilder.AddClientBlazorConfiguration();
+                    appBuilder.UseResponseCompression();
+
+                    if (environment.IsDevelopment())
+                    {
+                        appBuilder.UseDeveloperExceptionPage();
+                        appBuilder.UseWebAssemblyDebugging();
+                    }
+
+                    return appBuilder
+                       .UseCors(builder =>
+                       {
+                           var configuredOrigins = configuration.GetValue<string>("Cors:Origins");
+
+                           if (!string.IsNullOrEmpty(configuredOrigins))
+                           {
+                               var allowedOrigins = configuredOrigins.Split(',');
+
+                               builder.WithOrigins(allowedOrigins)
+                                   .AllowAnyHeader()
+                                   .AllowAnyMethod();
+                           }
+
+                       }).UseDefaultFiles().UseStaticFiles();
+                },
+                postConfigure: appBuilder =>
+                {
+                    return appBuilder.UseAuthentication()
+                    .UseAuthorization()
+                    .UseBlazorFrameworkFiles()
+                    .UseSwagger()
+                    .UseSwaggerUI(setup =>
+                    {
+                        setup.EnableDeepLinking();
+                        setup.OAuthScopeSeparator(" ");
+                        setup.OAuthUsePkce();
+
+                        foreach (var description in apiVersion.ApiVersionDescriptions)
+                        {
+                            setup.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", description.GroupName);
+                        }
+                    });
+                });
+
+            return app;
+        }
+    }
+}

--- a/src/Esquio.UI.Deployment/Setup/EsquioServiceCollectionExtensions.cs
+++ b/src/Esquio.UI.Deployment/Setup/EsquioServiceCollectionExtensions.cs
@@ -1,0 +1,76 @@
+﻿using Esquio.UI.Api;
+using Esquio.UI.Api.Infrastructure.HostedService;
+using Esquio.UI.Api.Infrastructure.Services;
+using Esquio.UI.Api.Infrastructure.Settings;
+using Esquio.UI.Deployment.Infrastructure.OpenApi;
+using Esquio.UI.Deployment.Infrastructure.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Linq;
+using System.Net.Mime;
+
+namespace Esquio.UI.Deployment.Setup
+{
+    public static class EsquioServiceCollectionExtensions
+    {
+        public static IServiceCollection AddEsquioServices(this IServiceCollection services, IConfiguration configuration, IWebHostEnvironment environment)
+        {
+            services
+                .AddHttpClient()
+                .AddCors()
+                .AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerGenOptions>()
+                .AddSingleton<IDiscoverToggleTypesService, DiscoverToggleTypesService>()
+                .AddResponseCompression(options =>
+                {
+                    options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(
+                        new[] { MediaTypeNames.Application.Octet });
+                })
+                .AddSwaggerGen()
+                .AddApplicationInsightsTelemetry()
+                .AddAuthentication(options =>
+                {
+                    options.DefaultScheme = "secured";
+                    options.DefaultChallengeScheme = "secured";
+                })
+                .AddApiKey()
+                .AddJwtBearer(options =>
+                {
+                    var securitySettings = new SecuritySettings();
+                    configuration.Bind("Security", securitySettings);
+
+                    options.Audience = securitySettings.OpenId.Audience;
+                    options.Authority = securitySettings.OpenId.Authority;
+
+                    options.TokenValidationParameters.ValidateIssuer = false;
+                })
+                .AddPolicyScheme("secured", "Authorization Bearer or ApiKey", options =>
+                {
+                    options.ForwardDefaultSelector = context =>
+                    {
+                        var bearer = context.Request
+                            .Headers["Authorization"]
+                            .FirstOrDefault();
+
+                        if (bearer != null && bearer.StartsWith(JwtBearerDefaults.AuthenticationScheme))
+                        {
+                            return JwtBearerDefaults.AuthenticationScheme;
+                        }
+
+                        return ApiKeyAuthenticationDefaults.ApiKeyScheme;
+                    };
+                });
+
+            EsquioUIApiConfiguration.ConfigureServices(services, configuration)
+                .AddEntityFramework(configuration, environment)
+                .AddHostedService<EsquioMetricsConsumer>();
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
Hi,

In order to make it easy to deploy the UI for a client application, we're proposing this PR to create a single deployment package (`Esquio.UI.Deployment`)

Then, deploying the UI would just be a matter of creating a very simple project and include the package, as shown in the `demo/Esquio.UI.Web` application, without the need to clone/fork this repo.

## WARNING: This PR is for the `releases/v4.0` branch

Because we're using .NET Core 3.1