### PR TITLE
Add audience to oidc provider options

### DIFF
--- a/src/Esquio.UI.Client/Program.cs
+++ b/src/Esquio.UI.Client/Program.cs
@@ -30,6 +30,7 @@ namespace Esquio.UI.Client
 
             var isAzureAd = builder.Configuration.GetValue<bool>("Security:IsAzureAd");
             var authority = builder.Configuration.GetValue<string>("Security:Authority");
+            var audience = builder.Configuration.GetValue<string>("Security:Audience");
             var clientId = builder.Configuration.GetValue<string>("Security:ClientId");
             var scope = builder.Configuration.GetValue<string>("Security:Scope");
             var responseType = builder.Configuration.GetValue<string>("Security:ResponseType");
@@ -53,10 +54,11 @@ namespace Esquio.UI.Client
                     options.ProviderOptions.ClientId = clientId;
                     options.ProviderOptions.ResponseType = responseType;
                     options.ProviderOptions.DefaultScopes.Add(scope);
+                    options.ProviderOptions.AdditionalProviderParameters.Add(nameof(audience), audience);
                 });
             }
 
-           
+
             builder.Services.AddAuthorizationCore(options =>
             {
                 options.AddPolicy(Policies.Reader, builder => builder.AddRequirements(new PolicyRequirement(Policies.Reader)));
@@ -72,7 +74,7 @@ namespace Esquio.UI.Client
             builder.Services.AddScoped<IAuthorizationHandler, PolicyRequirementHandler>();
 
 
-            var host =  builder.Build();
+            var host = builder.Build();
 
             var jsRuntime = builder.Services.BuildServiceProvider().GetRequiredService<IJSRuntime>();
             await jsRuntime.InvokeVoidAsync("addAuthenticationScript", new object[] { isAzureAd });


### PR DESCRIPTION
Hi! Tried to set up Esquio with Auth0 and got some issues with the token validation. The application was returning a 401 Bearer error="invalid_token" response and parsing the token in jwt.io showed no payload.

Finally found out that Auth0 requires the audience to be sent during the authorization request, which can be achieved by adding it to the provider options.

References:
- [Securing Blazor WebAssembly Apps](https://auth0.com/blog/securing-blazor-webassembly-apps/)
- [Invalid access token payload, jwt encrypted with A256GCM](https://community.auth0.com/t/invalid-access-token-payload-jwt-encrypted-with-a256gcm/77893)

Tested the application with Auth0 and Duende demo server and everything was working just fine after the proposed change.

Thanks for the awesome work! 